### PR TITLE
fix: include `postInitScript.js` in package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "type": "commonjs",
   "files": [
     "template/*",
-    "template.config.js"
+    "template.config.js",
+    "postInitScript.js"
   ],
   "dependencies": {},
   "devDependencies": {},

--- a/postInitScript.js
+++ b/postInitScript.js
@@ -3,7 +3,7 @@
 const chalk = require("chalk");
 const path = require("path");
 
-function printInitScript(projectName) {
+function printInitScript() {
   const projectDir = path.resolve();
 
   const instructions = `
@@ -18,9 +18,7 @@ function printInitScript(projectName) {
     • npx react-native run-visionos
     `;
 
-  console.log(`
-  ${instructions}
-  `);
+  console.log(instructions);
 }
 
 printInitScript();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Recently published version `0.75.1-rc.0` doesn't contain `postInitScript.js` because it's not included inside `files/` property in `package.json`.

## Changelog:

[GENERAL] [FIXED] - Include `postInitScript.js` in package files

## Test Plan:

After release `postInitScript.js` should be included in package files.
