### PR TITLE
fix: remove `chalk` dependency from `postInitScript.js`

### DIFF
--- a/postInitScript.js
+++ b/postInitScript.js
@@ -1,13 +1,17 @@
 #!/usr/bin/env node
 
-const chalk = require("chalk");
 const path = require("path");
+
+// ANSI escape codes for colors and formatting
+const reset = "\x1b[0m";
+const cyan = "\x1b[36m";
+const bold = "\x1b[1m";
 
 function printInitScript() {
   const projectDir = path.resolve();
 
   const instructions = `
-    ${chalk.cyan(`Run instructions for ${chalk.bold("visionOS")}`)}:
+    ${cyan}Run instructions for ${bold}visionOS${reset}${cyan}:${reset}
     • cd "${projectDir}/visionos"
 
     • Install Cocoapods


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When executing `postInitScript.js` inside `/tmp` files `chalk` package is not available - for this case it's easier to just replace its usage with ANSI escape codes. 

## Changelog:

[GENERAL] [FIXED] - Remove `chalk` dependency from `postInitScript.js` 

## Test Plan:

`node postInitScript.js`